### PR TITLE
Adjust navbar link colors to DaisyUI base-content

### DIFF
--- a/src/components/shared/Header.astro
+++ b/src/components/shared/Header.astro
@@ -17,11 +17,11 @@
         </div>
         <ul tabindex="0"
             class="menu menu-sm dropdown-content mt-3 z-[1] p-2 shadow bg-base-100 rounded-box w-52">
-          <li><a class="min-h-11 flex items-center" href="/">Homepage</a></li>
-          <li><a class="min-h-11 flex items-center" href="/blog">Blog</a></li>
-          <li><a class="min-h-11 flex items-center" href="/tags">Tags</a></li>
-          <li><a class="min-h-11 flex items-center" href="/legal">Legal</a></li>
-          <li><a class="min-h-11 flex items-center" href="/newsletter">newsletter</a></li>
+          <li><a class="min-h-11 flex items-center text-base-content" href="/">Homepage</a></li>
+          <li><a class="min-h-11 flex items-center text-base-content" href="/blog">Blog</a></li>
+          <li><a class="min-h-11 flex items-center text-base-content" href="/tags">Tags</a></li>
+          <li><a class="min-h-11 flex items-center text-base-content" href="/legal">Legal</a></li>
+          <li><a class="min-h-11 flex items-center text-base-content" href="/newsletter">newsletter</a></li>
 
         </ul>
       </div>
@@ -32,10 +32,10 @@
 
     <!-- RIGHT: Links (desktop only) -->
     <div class="navbar-end hidden lg:flex gap-4">
-      <a href="/blog" class="btn btn-ghost btn-primary text-sm">/blog</a>
-      <a href="/tags" class="btn btn-ghost btn-secondary text-sm">/tags</a>
-      <a href="/legal" class="btn btn-ghost btn-info text-sm">/legal</a>
-      <a href="/newsletter" class="btn btn-ghost btn-neutral text-sm">/newsletter</a>
+      <a href="/blog" class="btn btn-ghost text-base-content text-sm">/blog</a>
+      <a href="/tags" class="btn btn-ghost text-base-content text-sm">/tags</a>
+      <a href="/legal" class="btn btn-ghost text-base-content text-sm">/legal</a>
+      <a href="/newsletter" class="btn btn-ghost text-base-content text-sm">/newsletter</a>
     </div>
 
   </div>


### PR DESCRIPTION
## Summary
- update desktop and mobile navbar link color classes to use DaisyUI `text-base-content`
- remove per-link semantic color variants in the header for a consistent nav appearance

## Verification
- `npm run build`