### PR TITLE
Use tag-based related reads with latest-post fallback

### DIFF
--- a/src/content/blog/10-cli-tools-that-skilled-developers-obsess-over.md
+++ b/src/content/blog/10-cli-tools-that-skilled-developers-obsess-over.md
@@ -55,8 +55,3 @@ It only cares whether you can execute reliably.
 
 CLI tools reward deliberate practice.
 If you invest in the stack, it compounds into real speed and calmer delivery.
-
-## Related Reading
-
-- [Neovim Made Me Twice as Fast - My Developer Workflow](/blog/neovim-made-me-twice-as-fast/)
-- [The Indie Developer Stack 2025 — Django, Vue, Astro, Flutter](/blog/the-indie-developer-stack-2025/)

--- a/src/content/blog/7-powerful-ways-to-use-ai-agents-to-make-more-money.md
+++ b/src/content/blog/7-powerful-ways-to-use-ai-agents-to-make-more-money.md
@@ -74,9 +74,3 @@ If you do it right, you’ll never work the same way again.
 
 **Want help building your first AI agent?** 
 Drop me a line at [baileyburnsed.dev](https://baileyburnsed.dev) or follow [@baileyburnsed](https://twitter.com/baileyburnsed) for more tips.
-
-## Related Reading
-
-- [AI Agents for Solo Teams: Implementation Playbook](/blog/ai-agents-for-solo-teams-playbook/)
-- [The AI Agent Stack for Solo Developers](/blog/the-ai-agent-stack-for-solo-developers/)
-

--- a/src/content/blog/Own-Dont-Rent-10-Self-host-tools-for-small-business.md
+++ b/src/content/blog/Own-Dont-Rent-10-Self-host-tools-for-small-business.md
@@ -137,10 +137,3 @@ No subscriptions. No hidden fees. No shutdowns.
 Your business deserves stability — not permission slips. So stop renting your tools. Own them.
 
 Own your apps. Own your data. Own your business.
-
-## Related Reading
-
-- [Self-Hosting Playbook for Small SaaS Teams](/blog/self-hosting-playbook-for-small-saas/)
-- [Own, Don’t Rent — Why Self-Hosting Beats SaaS for Small Businesses](/blog/own-dont-rent-the-hidden-cost-of-saas/)
-- [The $5 VPS Stack That Scales to the Cloud](/blog/the-5-dollar-vps-stack-that-scales-to-the-cloud/)
-

--- a/src/content/blog/Own-Dont-Rent-When-to-use-a-CMS.md
+++ b/src/content/blog/Own-Dont-Rent-When-to-use-a-CMS.md
@@ -82,8 +82,3 @@ Control improves resilience.
 Resilience protects margin.
 
 If the site is core to revenue, owning your stack is usually the better long-term decision.
-
-## Related Reading
-
-- [Self-Hosting Playbook for Small SaaS Teams](/blog/self-hosting-playbook-for-small-saas/)
-- [Own, Don’t Rent — Why Self-Hosting Beats SaaS for Small Businesses](/blog/own-dont-rent-the-hidden-cost-of-saas/)

--- a/src/content/blog/ai-agents-for-solo-teams-playbook.md
+++ b/src/content/blog/ai-agents-for-solo-teams-playbook.md
@@ -79,9 +79,3 @@ Week 2: add queueing + retries + observability.
 Week 3: integrate into one customer-facing workflow with approval gate.
 
 Week 4: review metrics, remove low-value automations, expand only proven flows.
-
-## Related Reading
-
-- [The AI Agent Stack for Solo Developers](/blog/the-ai-agent-stack-for-solo-developers/)
-- [BulkPost 2.0 — Turning My Twitter Bot Into an Agentic AI Social Media System](/blog/bulkpost-2-agentic-ai-social-media/)
-- [7 Powerful Ways to Use AI Agents to Make More Money](/blog/7-powerful-ways-to-use-ai-agents-to-make-more-money/)

--- a/src/content/blog/building-a-business-without-venture-capital.md
+++ b/src/content/blog/building-a-business-without-venture-capital.md
@@ -75,8 +75,3 @@ If control matters to you, design for revenue early and keep operations lean.
 If you are building without VC and want a delivery system that can hold up under real client pressure, I can help.
 [Schedule a 15-minute Zoom call](https://calendly.com/baileyburnsed/15min)
 Or [Start your 30-day development plan now](https://baileyburnsed.dev/)
-
-## Related Reading
-
-- [Indie SaaS Growth Playbook for Technical Founders](/blog/indie-saas-growth-playbook/)
-- [Why I Charge $4000 a Month — The Flat-Rate Developer Model](/blog/why-i-charge-4000-a-month/)

--- a/src/content/blog/bulkpost-2-agentic-ai-social-media.md
+++ b/src/content/blog/bulkpost-2-agentic-ai-social-media.md
@@ -144,10 +144,3 @@ Follow the rebuild.
 BulkPost 2.0 will be open-source and fully self-hostable — an AI social media engine you own.
 [Schedule a 15-minute Zoom call](https://calendly.com/baileyburnsed/15min)
 Or [Start your 30-day development plan now](https://baileyburnsed.dev/)
-
-## Related Reading
-
-- [AI Agents for Solo Teams: Implementation Playbook](/blog/ai-agents-for-solo-teams-playbook/)
-- [The AI Agent Stack for Solo Developers](/blog/the-ai-agent-stack-for-solo-developers/)
-- [Indie SaaS Growth Playbook for Technical Founders](/blog/indie-saas-growth-playbook/)
-

--- a/src/content/blog/freelancing-as-a-autistic-developer.md
+++ b/src/content/blog/freelancing-as-a-autistic-developer.md
@@ -61,9 +61,3 @@ Autistic people are often unemployed or underemployed, this is often due to havi
 With Productized Services you can have full control of your schedule, weaponize your autism to make scalable and very profitable business
 
 this will allow us to make a living off of our special interests more easily or do work that pays the bills so we can focus on our special interests if it is not practical to monetize them
-
-## Related Reading
-
-- [Why I Charge $4000 a Month — The Flat-Rate Developer Model](/blog/why-i-charge-4000-a-month/)
-- [Pricing Strategy for Developers Who Think Too Much](/blog/pricing-strategy-for-developers-who-think-too-much/)
-- [The One Developer Agency Model](/blog/the-one-developer-agency-model/)

--- a/src/content/blog/from-games-to-saas.md
+++ b/src/content/blog/from-games-to-saas.md
@@ -82,8 +82,3 @@ If you want to turn your SaaS idea into a product that people *want* to use:
 
 [Schedule a 15-minute Zoom call](https://calendly.com/baileyburnsed/15min)
 Or [Start your 30-day development plan now](https://baileyburnsed.dev/)
-
-## Related Reading
-
-- [Indie SaaS Growth Playbook for Technical Founders](/blog/indie-saas-growth-playbook/)
-- [From MVP to MRR: How to Productize Your Side Projects](/blog/from-mvp-to-mrr-how-to-productize-your-side-projects/)

--- a/src/content/blog/from-hourly-freelancing-to-ai-automation.md
+++ b/src/content/blog/from-hourly-freelancing-to-ai-automation.md
@@ -120,9 +120,3 @@ And scale it.
 Curious:
 
 Have you experimented with **productized services** or **AI automation** yet?
-
-## Related Reading
-
-- [Why I Charge $4000 a Month — The Flat-Rate Developer Model](/blog/why-i-charge-4000-a-month/)
-- [Pricing Strategy for Developers Who Think Too Much](/blog/pricing-strategy-for-developers-who-think-too-much/)
-- [The One Developer Agency Model](/blog/the-one-developer-agency-model/)

--- a/src/content/blog/from-mvp-to-mrr-how-to-productize-your-side-projects.md
+++ b/src/content/blog/from-mvp-to-mrr-how-to-productize-your-side-projects.md
@@ -95,10 +95,3 @@ Want help turning your side project into a SaaS or productized service?
 That’s what I specialize in — helping developers and founders go from idea to income.
 [Schedule a 15-minute Zoom call](https://calendly.com/baileyburnsed/15min)
 Or [start your 30-day development plan](https://baileyburnsed.dev)
-
-## Related Reading
-
-- [Indie SaaS Growth Playbook for Technical Founders](/blog/indie-saas-growth-playbook/)
-- [Pricing Strategy for Developers Who Think Too Much](/blog/pricing-strategy-for-developers-who-think-too-much/)
-- [Why I Charge $4000 a Month — The Flat-Rate Developer Model](/blog/why-i-charge-4000-a-month/)
-

--- a/src/content/blog/indie-saas-growth-playbook.md
+++ b/src/content/blog/indie-saas-growth-playbook.md
@@ -76,10 +76,3 @@ If a metric does not drive a decision, remove it.
 - distribution that depends on "when I have time"
 
 The fix is almost always sharper constraints, not more tools.
-
-## Related Reading
-
-- [From MVP to MRR: How to Productize Your Side Projects](/blog/from-mvp-to-mrr-how-to-productize-your-side-projects/)
-- [The Indie Developer Stack 2025 — Django, Vue, Astro, Flutter](/blog/the-indie-developer-stack-2025/)
-- [Pricing Strategy for Developers Who Think Too Much](/blog/pricing-strategy-for-developers-who-think-too-much/)
-- [Why I Charge $4000 a Month — The Flat-Rate Developer Model](/blog/why-i-charge-4000-a-month/)

--- a/src/content/blog/neovim-made-me-twice-as-fast.md
+++ b/src/content/blog/neovim-made-me-twice-as-fast.md
@@ -164,9 +164,4 @@ Once you master the motions, you stop thinking about tools and start thinking ab
 I don’t measure productivity by lines of code anymore.  
 I measure it by how long I can stay in flow.  
 
-If you want to learn how to set up Neovim, automate your terminal workflow, or build apps with speed and focus - I teach this stuff.  
-
-## Related Reading
-
-- [10 CLI Tools That Skilled Developers Obsess Over](/blog/10-cli-tools-that-skilled-developers-obsess-over/)
-- [The Indie Developer Stack 2025 — Django, Vue, Astro, Flutter](/blog/the-indie-developer-stack-2025/)
+If you want to learn how to set up Neovim, automate your terminal workflow, or build apps with speed and focus - I teach this stuff.

--- a/src/content/blog/own-dont-rent-the-hidden-cost-of-saas.md
+++ b/src/content/blog/own-dont-rent-the-hidden-cost-of-saas.md
@@ -90,10 +90,3 @@ Want to transition your business away from SaaS dependence?
 I can help you migrate, deploy, and customize your own stack.
 [Schedule a 15-minute Zoom call](https://calendly.com/baileyburnsed/15min)
 Or [Start your 30-day development plan now](https://baileyburnsed.dev/)
-
-## Related Reading
-
-- [Self-Hosting Playbook for Small SaaS Teams](/blog/self-hosting-playbook-for-small-saas/)
-- [Own, Don't Rent](/blog/own-dont-rent-10-self-host-tools-for-small-business/)
-- [Self-Hosting as a Service: How I Run Client SaaS on Fly.io](/blog/self-hosting-as-a-service-how-i-run-client-saas-on-fly/)
-

--- a/src/content/blog/pricing-strategy-for-developers-who-think-too-much.md
+++ b/src/content/blog/pricing-strategy-for-developers-who-think-too-much.md
@@ -108,9 +108,3 @@ If you solve hard problems, deliver fast, and communicate clearly, you’ve alre
 The smartest developers don’t race to the bottom —
 they build systems that pay them fairly for their expertise.
 *Written by Bailey Burnsed — Senior Software Engineer, Founder of BaileyBurnsed.dev*
-
-## Related Reading
-
-- [Indie SaaS Growth Playbook for Technical Founders](/blog/indie-saas-growth-playbook/)
-- [The One Developer Agency Model](/blog/the-one-developer-agency-model/)
-- [Why I Charge $4000 a Month — The Flat-Rate Developer Model](/blog/why-i-charge-4000-a-month/)

--- a/src/content/blog/self-hosting-as-a-service-how-i-run-client-saas-on-fly.md
+++ b/src/content/blog/self-hosting-as-a-service-how-i-run-client-saas-on-fly.md
@@ -125,10 +125,3 @@ Want your own white-label SaaS with open-source infrastructure and zero lock-in?
 That’s what I build — self-hosted, fast, and future-proof.
 [Schedule a 15-minute Zoom call](https://calendly.com/baileyburnsed/15min)
 Or [start your 30-day development plan](https://baileyburnsed.dev)
-
-## Related Reading
-
-- [Self-Hosting Playbook for Small SaaS Teams](/blog/self-hosting-playbook-for-small-saas/)
-- [Own, Don’t Rent — Why Self-Hosting Beats SaaS for Small Businesses](/blog/own-dont-rent-the-hidden-cost-of-saas/)
-- [The $5 VPS Stack That Scales to the Cloud](/blog/the-5-dollar-vps-stack-that-scales-to-the-cloud/)
-

--- a/src/content/blog/self-hosting-playbook-for-small-saas.md
+++ b/src/content/blog/self-hosting-playbook-for-small-saas.md
@@ -68,10 +68,3 @@ Before calling a self-hosted setup "production ready," confirm:
 - secrets and access controls reviewed
 
 Teams skip these because the app "seems stable" until first real incident.
-
-## Related Reading
-
-- [Own, Don’t Rent — Why Self-Hosting Beats SaaS for Small Businesses](/blog/own-dont-rent-the-hidden-cost-of-saas/)
-- [Own, Don't Rent](/blog/own-dont-rent-10-self-host-tools-for-small-business/)
-- [Self-Hosting as a Service: How I Run Client SaaS on Fly.io](/blog/self-hosting-as-a-service-how-i-run-client-saas-on-fly/)
-- [The $5 VPS Stack That Scales to the Cloud](/blog/the-5-dollar-vps-stack-that-scales-to-the-cloud/)

--- a/src/content/blog/the-ai-agent-stack-for-solo-developers.md
+++ b/src/content/blog/the-ai-agent-stack-for-solo-developers.md
@@ -107,10 +107,3 @@ Want to build your own agentic AI system for marketing, SaaS, or client automati
 That’s exactly what I help developers and founders do.
 [Schedule a 15-minute Zoom call](https://calendly.com/baileyburnsed/15min)
 Or [start your 30-day development plan](https://baileyburnsed.dev)
-
-## Related Reading
-
-- [AI Agents for Solo Teams: Implementation Playbook](/blog/ai-agents-for-solo-teams-playbook/)
-- [BulkPost 2.0 — Turning My Twitter Bot Into an Agentic AI Social Media System](/blog/bulkpost-2-agentic-ai-social-media/)
-- [7 Powerful Ways to Use AI Agents to Make More Money](/blog/7-powerful-ways-to-use-ai-agents-to-make-more-money/)
-

--- a/src/content/blog/the-indie-developer-stack-2025.md
+++ b/src/content/blog/the-indie-developer-stack-2025.md
@@ -69,9 +69,3 @@ Want to build your SaaS or app with the same stack I use?
 
 [Schedule a 15-minute Zoom call](https://calendly.com/baileyburnsed/15min)
 Or [Start your 30-day development plan now](https://baileyburnsed.dev/)
-
-## Related Reading
-
-- [Indie SaaS Growth Playbook for Technical Founders](/blog/indie-saas-growth-playbook/)
-- [From MVP to MRR: How to Productize Your Side Projects](/blog/from-mvp-to-mrr-how-to-productize-your-side-projects/)
-

--- a/src/content/blog/why-i-charge-4000-a-month.md
+++ b/src/content/blog/why-i-charge-4000-a-month.md
@@ -92,8 +92,3 @@ If this philosophy resonates with you — or you need a reliable full-stack deve
 
 [Schedule a 15-minute Zoom call](https://calendly.com/baileyburnsed/15min)
 Or [Start your 30-day development plan now](https://baileyburnsed.dev/)
-
-## Related Reading
-
-- [Pricing Strategy for Developers Who Think Too Much](/blog/pricing-strategy-for-developers-who-think-too-much/)
-- [The One Developer Agency Model](/blog/the-one-developer-agency-model/)

--- a/src/content/blog/why-i-work-in-public.md
+++ b/src/content/blog/why-i-work-in-public.md
@@ -73,8 +73,3 @@ If you want help setting up your public dev process or content plan:
 
 [Schedule a 15-minute Zoom call](https://calendly.com/baileyburnsed/15min)
 Or [Start your 30-day development plan now](https://baileyburnsed.dev/)
-
-## Related Reading
-
-- [The Art of Building in Public](/blog/the-art-of-building-in-public/)
-- [Why Open Source Is My Marketing Strategy](/blog/why-open-source-is-my-marketing-strategy/)

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -19,7 +19,7 @@ const { Content } = await post.render();
 const allPosts = await getCollection('blog');
 const currentTags = getNormalizedTags(post.data.tags);
 
-const relatedPosts = allPosts
+const rankedRelatedPosts = allPosts
   .filter((candidate) => candidate.slug !== post.slug)
   .map((candidate) => {
     const candidateTags = getNormalizedTags(candidate.data.tags);
@@ -40,6 +40,13 @@ const relatedPosts = allPosts
   })
   .slice(0, 3)
   .map((item) => item.post);
+
+const fallbackRelatedPosts = allPosts
+  .filter((candidate) => candidate.slug !== post.slug)
+  .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf())
+  .slice(0, 3);
+
+const relatedPosts = rankedRelatedPosts.length > 0 ? rankedRelatedPosts : fallbackRelatedPosts;
 ---
 
 <BlogPost slug={post.slug} relatedPosts={relatedPosts} {...post.data}>


### PR DESCRIPTION
## Summary
- Keep blog related reads driven by shared `tags` and ranking by overlap/date.
- Add a fallback so posts with no tag overlap still show the latest 3 other posts.
- Remove manual `## Related Reading` markdown sections from 21 blog posts so related links come from one source of truth.

## Validation
- `npm run astro -- check` *(fails due to existing baseline errors in legacy components; no new errors introduced by this change)*
- `npm run build` *(passes)*